### PR TITLE
Не очищаются "старые" теги

### DIFF
--- a/system/controllers/tags/model.php
+++ b/system/controllers/tags/model.php
@@ -89,7 +89,7 @@ class modelTags extends cmsModel{
         
         $this->lockFilters();
         
-        $tags_ids = $this->get('favorites_tags_bind', function($item, $model){
+        $tags_ids = $this->get('tags_bind', function($item, $model){
             return $item['tag_id'];
         });
         

--- a/system/controllers/tags/model.php
+++ b/system/controllers/tags/model.php
@@ -86,7 +86,18 @@ class modelTags extends cmsModel{
     public function updateTags($tags_string, $controller, $subject, $id){
 
         $this->filterTarget($controller, $subject, $id);
+        
+        $this->lockFilters();
+        
+        $tags_ids = $this->get('favorites_tags_bind', function($item, $model){
+            return $item['tag_id'];
+        });
+        
+        $this->unlockFilters();
+        
         $this->deleteFiltered('tags_bind');
+        
+        if ($tags_ids) { $this->recountTagsFrequency($tags_ids); }
 
         return $this->addTags($tags_string, $controller, $subject, $id);
 


### PR DESCRIPTION
При редактировании записи и последующем вызове метода updateTags(...) удаляются связи с тегами в таблице {cms}_bind_tags но сами теги остаются в таблице {cms}_tags.