### PR TITLE
Удаляются теги из всех записей

### DIFF
--- a/system/controllers/tags/model.php
+++ b/system/controllers/tags/model.php
@@ -215,6 +215,10 @@ class modelTags extends cmsModel{
     }
 
     public function deleteTags($controller, $subject, $id){
+    	
+    	$tags_ids = $this->getTagsIDsForTarget($controller, $subject, $id);
+		
+		if (!$tags_ids) { return; }
 		
 	$this->filterTarget($controller, $subject, $id);
 

--- a/system/controllers/tags/model.php
+++ b/system/controllers/tags/model.php
@@ -216,18 +216,14 @@ class modelTags extends cmsModel{
 
     public function deleteTags($controller, $subject, $id){
     	
-    	$this->lockFilters();
-    	
     	$tags_ids = $this->filterTarget($controller, $subject, $id)->
                 get('tags_bind', function($item, $model){
                     return $item['tag_id'];
                 });
-                
-        $this->unlockFilters();
 		
 	if (!$tags_ids) { return; }
 
-        $this->deleteFiltered('tags_bind');
+        $this->filterIn('id', array_keys($tags_ids))->deleteFiltered('tags_bind');
 		
         cmsCache::getInstance()->clean("tags.tags");
 

--- a/system/controllers/tags/model.php
+++ b/system/controllers/tags/model.php
@@ -224,8 +224,6 @@ class modelTags extends cmsModel{
 	if (!$tags_ids) { return; }
 
         $this->filterIn('id', array_keys($tags_ids))->deleteFiltered('tags_bind');
-		
-        cmsCache::getInstance()->clean("tags.tags");
 
         $this->recountTagsFrequency(array_unique($tags_ids));
 

--- a/system/controllers/tags/model.php
+++ b/system/controllers/tags/model.php
@@ -215,14 +215,8 @@ class modelTags extends cmsModel{
     }
 
     public function deleteTags($controller, $subject, $id){
-
-        $tags_ids = $this->getTagsIDsForTarget($controller, $subject, $id);
-		
-		if (!$tags_ids) { return; }
 		
 	$this->filterTarget($controller, $subject, $id);
-		
-        $this->filterIn('tag_id', $tags_ids);
 
         $this->deleteFiltered('tags_bind');
 		

--- a/system/controllers/tags/model.php
+++ b/system/controllers/tags/model.php
@@ -216,17 +216,22 @@ class modelTags extends cmsModel{
 
     public function deleteTags($controller, $subject, $id){
     	
-    	$tags_ids = $this->getTagsIDsForTarget($controller, $subject, $id);
+    	$this->lockFilters();
+    	
+    	$tags_ids = $this->filterTarget($controller, $subject, $id)->
+                get('tags_bind', function($item, $model){
+                    return $item['tag_id'];
+                });
+                
+        $this->unlockFilters();
 		
-		if (!$tags_ids) { return; }
-		
-	$this->filterTarget($controller, $subject, $id);
+	if (!$tags_ids) { return; }
 
         $this->deleteFiltered('tags_bind');
 		
         cmsCache::getInstance()->clean("tags.tags");
 
-        $this->recountTagsFrequency($tags_ids);
+        $this->recountTagsFrequency(array_unique($tags_ids));
 
         return true;
 

--- a/system/core/database.php
+++ b/system/core/database.php
@@ -100,7 +100,7 @@ class cmsDatabase {
         $sql = str_replace(array(
             '{#}{users}', '{users}', '{#}'
         ), array(
-            $config->db_users_table, $config->db_users_table, $config->db_users_table
+            $config->db_users_table, $config->db_users_table, $this->prefix
         ), $sql);
 
         if ($params){


### PR DESCRIPTION
Я как-то говорил **r2** об этой "баге", но решил сюда тоже добавить...
При удалении одной из записей с тегом (или несколькими тегами), который содержится еще в других записях, этот тег полностью удаляется из таблицы **{#}_tags**, и соответственно из всех остальных записей! Дополнительная фильтрация решает данную проблему.