### PR TITLE
Исправление невозможности установить атрибут disabled для любого инпута

### DIFF
--- a/system/libs/html.helper.php
+++ b/system/libs/html.helper.php
@@ -260,6 +260,7 @@ function html_attr_str($attributes){
     unset($attributes['class']);
     if (sizeof($attributes)){
         foreach($attributes as $key=>$val){
+            if ($key=='disabled') { $attr_str .=  $val ? $key : ''; continue; }
             $attr_str .= "{$key}=\"{$val}\" ";
         }
     }


### PR DESCRIPTION
При установке атрибута **disabled**, например так 
```php
<?php echo html_input('text', 'blabla', $blablabla, array(
                                      'class'=>'blablablabla',
                                      'disabled' => $do=='update' ? true : false  // <- вот тут проблема (true/false для наглядности)
)); ?>
```
**input** будет недоступным (disable'нутым) в любом случае.