### PR TITLE
Поддержка формата шрифта woff2

### DIFF
--- a/templates/.htaccess
+++ b/templates/.htaccess
@@ -1,4 +1,4 @@
 order allow,deny
-<Files ~ "\.(js|css|xml|png|gif|jpg|jpeg|html|htm|ico|bmp|map|eot|svg|ttf|woff)$">
+<Files ~ "\.(js|css|xml|png|gif|jpg|jpeg|html|htm|ico|bmp|map|eot|svg|ttf|woff|woff2)$">
    allow from all
 </Files>


### PR DESCRIPTION
При подключении гугл шрифта, один из форматов шрифта предоставляемый им это woff2, так же он более оптимизирован, предлогаю включить его в список разрешенных форматов файлов.