### PR TITLE
Список каталогов в алфавитном порядке

### DIFF
--- a/system/core/core.php
+++ b/system/core/core.php
@@ -874,11 +874,11 @@ class cmsCore {
     public static function getDirsList($root_dir){
 
         $dir = cmsConfig::get('root_path') . $root_dir;
-        $dir_context = opendir($dir);
+        $dir_context = scandir($dir,0);
 
         $list = array();
 
-        while ($next = readdir($dir_context)){
+        foreach ($dir_context as $next){
 
             if (in_array($next, array('.', '..'))){ continue; }
             if (strpos($next, '.') === 0){ continue; }


### PR DESCRIPTION
Функция readdir() возвращает элементы в том порядке, в котором они хранятся в файловой системе. В итоге может возникнуть разный порядок выполнения хуков на некоторых хостингах. Функция  scandir($dir,0) возвращает элементы отсортированные в порядке возрастания по алфавиту. 