### PR TITLE
Загружаем стили из default, если их нет в шаблоне

### DIFF
--- a/system/core/template.php
+++ b/system/core/template.php
@@ -1372,7 +1372,9 @@ class cmsTemplate {
     public function getAvailableContentListStyles(){
 
         $files = cmsCore::getFilesList('templates/'.$this->name.'/content', 'default_list*.tpl.php', true);
-        if (!$files) { return false; }
+        $default_files = cmsCore::getFilesList('templates/default/content', 'default_list*.tpl.php', true);        
+	$files = array_unique(array_merge($files, $default_files));
+	if (!$files) { return false; }
 
         $styles = array();
 


### PR DESCRIPTION
Загружаем стили типов контента из папки /templates/default/content/ если их нет в текущем шаблоне...
Если есть, объединяем два массива и удаляем дубли...