### PR TITLE
Загружаем стили rss из default, если их нет в шаблоне

### DIFF
--- a/system/controllers/rss/backend/forms/form_feed.php
+++ b/system/controllers/rss/backend/forms/form_feed.php
@@ -35,6 +35,10 @@ class formRssFeed extends cmsForm {
                         'generator' => function($item) {
 
                             $tpls = cmsCore::getFilesList('templates/'.cmsConfig::get('template').'/controllers/rss/', '*.tpl.php');
+							
+                            $default_tpls = cmsCore::getFilesList('templates/default/controllers/rss/', '*.tpl.php');
+							
+			    $tpls = array_unique(array_merge($tpls, $default_tpls));
 
                             $items = array();
 


### PR DESCRIPTION
Если в основном шаблоне нет стили для rss, то возникают ошибка 503 Service Unavailable