### PR TITLE
Ошибка в строке 1443

### DIFF
--- a/system/libs/phpmailer/class.phpmailer.php
+++ b/system/libs/phpmailer/class.phpmailer.php
@@ -1440,7 +1440,7 @@ class PHPMailer
     public function getSMTPInstance()
     {
         if (!is_object($this->smtp)) {
-            $this->smtp = new SMTP;
+             $this->smtp = new SMTP;
         }
         return $this->smtp;
     }


### PR DESCRIPTION
Если в настройках сайта используется отправка почты через smtp, то она не работает и вызывает 500 ошибку.
В логах ошибка: 
PHP Fatal error:  Class 'SMTP' not found in /var/www/.../system/libs/phpmailer/class.phpmailer.php on line 1443 
Вот данная строка: $this->smtp = new SMTP;
Думаю вызвана тем, что нигде не подгружается файл - class.smtp.php из папки с phpmailer и система не может найти класс SMTP.
Строку выделил лишним пробелом.
Посмотрите пожалуйста.