### PR TITLE
Исправлено отображение кнопки редактирования и удаления виджетов в па…

### DIFF
--- a/templates/default/controllers/admin/styles.css
+++ b/templates/default/controllers/admin/styles.css
@@ -1312,6 +1312,7 @@ table.layout-no-fit td.main .loading { background:url("../../images/loader16.gif
     overflow: hidden;
 	height: 16px;
 	line-height: 16px;
+    position: relative;
 }
 
 #cp-widgets-layout .position li.tabbed{
@@ -1350,11 +1351,13 @@ table.layout-no-fit td.main .loading { background:url("../../images/loader16.gif
     margin-bottom: 0;
 }
 
-#cp-widgets-layout li .actions,
+#cp-widgets-layout li .actions, 
 #cp-widgets-list li .actions {
-    overflow: hidden;
-    float:right;
-    display:block;
+  display: block;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: 5px;
 }
 
 #cp-widgets-layout li .actions a ,


### PR DESCRIPTION
Исправлено отображение кнопки редактирования и удаления виджетов в панели управления виджетов. Если в строке с названием виджета не хватает места для этих кнопок, то они переходят на следующую строку и на них почти невозможно кликнуть. Сделал абсолютное позиционирование элементов и выровнял по правому краю.
До 
![2016-02-14 14-50-15](https://cloud.githubusercontent.com/assets/3851365/13033514/574cb4f4-d32a-11e5-8df3-fe34774c18cb.png)
После
![2016-02-14 14-49-25](https://cloud.githubusercontent.com/assets/3851365/13033509/3912c00a-d32a-11e5-8620-f598a35f02ad.png)
