### PR TITLE
Удобно выбирать ID из массивов

### DIFF
--- a/system/libs/strings.helper.php
+++ b/system/libs/strings.helper.php
@@ -555,7 +555,7 @@ function string_compress($string){
  */
 function array_collection_to_list($collection, $key, $value=false){
 
-    $value = $value ?: $key;
+    $value = $value ? $value : $key;
 
     $list = array();
 

--- a/system/libs/strings.helper.php
+++ b/system/libs/strings.helper.php
@@ -553,7 +553,9 @@ function string_compress($string){
  * @param type $value
  * @return type
  */
-function array_collection_to_list($collection, $key, $value){
+function array_collection_to_list($collection, $key, $value=false){
+
+    $value = $value ?: $key;
 
     $list = array();
 


### PR DESCRIPTION
Достаточно часто необходимо устанавливать одинаковые значения ключа ($key) и значения ($value) для выборки элементов из массива.
Изменения позволяют сократить код до следующего:
`$ids = array_collection_to_list($array, 'id');`