### PR TITLE
В массив с полями формы добавляем поля с ключами-именами.

### DIFF
--- a/system/core/form.php
+++ b/system/core/form.php
@@ -178,7 +178,7 @@ class cmsForm {
      */
     public function addField($fieldset_id, $field){
 
-        $this->structure[ $fieldset_id ]['childs'][] = $field;
+        $this->structure[ $fieldset_id ]['childs'][$field->name] = $field;
 
     }
 


### PR DESCRIPTION
Возникла необходимость взаимодействия с полями форм у дополнения iForms. iForms использует системные механизмы для формирования форм. 
Из группы полей получить конкретное нельзя, только перебором элементов. Предлагаю добавлять поле в группу полей с ключем - именем этого поля. 
Это не изменит работу CMS никаким образом, но в будущем даст возможность удобнее взаимодействовать с полями как контента, так и форм.