### PR TITLE
Исправление конвертации HTML-письма в TXT-вариант

### DIFF
--- a/system/core/mailer.php
+++ b/system/core/mailer.php
@@ -122,7 +122,7 @@ class cmsMailer {
         $this->mailer->MsgHTML( $message );
 
         if ($is_auto_alt){
-            $this->setBodyText( strip_tags($message) );
+            $this->setBodyText( $this->mailer->html2text($message) );
         }
 
         return $this;


### PR DESCRIPTION
При отправлении сложного HTML-письма, с тегами <style>, всё их наполнение оказывается внутри текстовой версии, наряду с чистым текстом письма из-за использования strip_tags.
Предлагаю воспользоваться готовым инструментом PHPMailer, который с чисткой HTML-письма справляется лучше :)
