### PR TITLE
User groups fix

### DIFF
--- a/system/controllers/users/model.php
+++ b/system/controllers/users/model.php
@@ -205,14 +205,15 @@ class modelUsers extends cmsModel{
 
         }
 
-        if (!$errors){
+        if (!empty($user['groups']) && !$errors){
 
-            $user['groups'] = !empty($user['groups']) ? $user['groups'] : array(DEF_GROUP_ID);
-
-            $success = $this->update('{users}', $id, $user);
+            if (!is_array($user['groups'])) $user['groups'] = array(DEF_GROUP_ID);
 
             $this->saveUserGroupsMembership($id, $user['groups']);
+        }
 
+        if (!$errors){
+            $success = $this->update('{users}', $id, $user);
         }
 
         cmsCache::getInstance()->clean("users.list");


### PR DESCRIPTION
Столкнулся с проблемой при написании хука по автоматической смене пароля определенному пользователю по расписанию. Группа пользователя принудительно обновлялась на "Новые", т.к. не была мной указана, ибо меняться не должна была.

Исправление делает обновление групп пользователя опциональным - только если в переданных данных массив с ID групп указаны явно.