### PR TITLE
Сохранение всех опций контроллера

### DIFF
--- a/system/core/backend.php
+++ b/system/core/backend.php
@@ -75,7 +75,7 @@ class cmsBackend extends cmsController {
 
         if ($this->request->has('submit')){
 
-            $options = array_merge( $options, $form->parse($this->request, true, $options) );
+            $options = array_merge( $options, $form->parse($this->request, true) );
             $errors  = $form->validate($this, $options);
 
             if (!$errors){

--- a/system/core/backend.php
+++ b/system/core/backend.php
@@ -75,6 +75,8 @@ class cmsBackend extends cmsController {
 
         if ($this->request->has('submit')){
 
+            $old_options = $options;
+            
             $options = $form->parse($this->request, true);
             $errors = $form->validate($this, $options);
 
@@ -82,7 +84,7 @@ class cmsBackend extends cmsController {
 
                 cmsUser::addSessionMessage(LANG_CP_SAVE_SUCCESS, 'success');
 
-                cmsController::saveOptions($this->name, $options);
+                cmsController::saveOptions($this->name, array_replace($old_options, $options));
 
                 $this->processCallback(__FUNCTION__, array($options));
 

--- a/system/core/backend.php
+++ b/system/core/backend.php
@@ -75,16 +75,14 @@ class cmsBackend extends cmsController {
 
         if ($this->request->has('submit')){
 
-            $old_options = $options;
-            
-            $options = $form->parse($this->request, true);
-            $errors = $form->validate($this, $options);
+            $options = array_merge( $options, $form->parse($this->request, true, $options) );
+            $errors  = $form->validate($this, $options);
 
             if (!$errors){
 
                 cmsUser::addSessionMessage(LANG_CP_SAVE_SUCCESS, 'success');
 
-                cmsController::saveOptions($this->name, array_replace($old_options, $options));
+                cmsController::saveOptions($this->name, $options);
 
                 $this->processCallback(__FUNCTION__, array($options));
 


### PR DESCRIPTION
В ряде случаев есть необходимость выносить часть параметров из формы опций на другие формы админки компонента с последующим сохранением их через 
```
$options = cmsController::loadOptions($this->controller->name);
// здесь добавляем новых опций
cmsController::saveOptions($this->controller->name, $options);
```
При этом если внести изменения и нажать кнопку сабмита на стандартной форме опций, все ранее сохранённые параметры будут утеряны.

Commit добавляет пересохранение только массива стандартных опций не трогая параметры из других форм.