### PR TITLE
Исполнение любых функций в экшенах контроллеров

### DIFF
--- a/system/core/controller.php
+++ b/system/core/controller.php
@@ -357,7 +357,7 @@ class cmsController {
      * Выполняет экшен, находящийся в отдельном файле ./actions/$action_name.php
      * @param str $action_name
      */
-    public function runExternalAction($action_name, $params = array()){
+    public function runExternalAction($action_name, $params = array(), $function_name = 'run'){
 
         $action_file = $this->root_path . 'actions/'.$action_name.'.php';
 
@@ -367,7 +367,7 @@ class cmsController {
 
         // проверяем максимальное число аргументов экшена
         if ($this->name != 'admin'){
-            $rf = new ReflectionMethod($class_name, 'run');
+            $rf = new ReflectionMethod($class_name, $function_name);
             $max_params = $rf->getNumberOfParameters();
             if ($max_params < count($params)) { cmsCore::error404(); }
         }
@@ -379,7 +379,7 @@ class cmsController {
             cmsCore::error404();
         }
 
-        return call_user_func_array(array($action_object, 'run'), $params);
+        return call_user_func_array(array($action_object, $function_name), $params);
 
     }
 


### PR DESCRIPTION
_Этот коммит больше как "хотелка"._
Сейчас в методе **runExternalAction()** жестко прописано выполнять только функцию run. Ранее я уже сталкивался с потребностью использовать функцию прописанную во внешнем экшене из другого экшена, но в конечном итоге перенёс эту функцию в файл frontend.php и тянул уже оттуда. Сейчас снова поднялся подобный вопрос, и на этот раз я переопределил **runExternalAction()** в своем контроллере и уже через нее запускаю нужные функции из внешних экшенов.

Сразу отвечу на вопрос почему не хочу переносить эти функции во **frontend.php** или **backend.php**.  Логически и идеологически эти функции принадлежать своим экшенам в которых они используются, и переносить все их в общую кучу выглядит не очень... Также и при их использовании из других файлов получается красиво и понятно (видно к чему относится конкретная функция).

Можно конечно и самим набросать обертку для **include_once**, и использовать ее в своих компонентах. Но есть же уже _почти_ готовая в InstantCMS =)