### PR TITLE
Опечатка в стиле

### DIFF
--- a/templates/default/css/theme-gui.css
+++ b/templates/default/css/theme-gui.css
@@ -1612,7 +1612,7 @@ form .ft_listmultiple.field_error .input_checkbox_list {
 
 #pm_notices_list .item{
     overflow: hidden;
-    border: solid  1px #BDC3C7;
+    border: solid 1px #BDC3C7;
     background:#e1ebef;
     padding:5px;
     padding-right:5px;


### PR DESCRIPTION
При включенной опции сжатие css в данной строке ошибка из-за двойного пробела.