### PR TITLE
Исправление работы параметра 'Показывать стену пользователя'

### DIFF
--- a/system/controllers/groups/actions/add.php
+++ b/system/controllers/groups/actions/add.php
@@ -8,6 +8,10 @@ class actionGroupsAdd extends cmsAction {
 
         $form = $this->getForm('group');
 
+        if (!$this->options['is_wall']){
+            $form->removeField('basic', 'wall_policy');
+        }
+
         $is_submitted = $this->request->has('submit');
 
         $group = $form->parse($this->request, $is_submitted);


### PR DESCRIPTION
При создании группы не зависимо от параметра 'Показывать стену пользователя' выводился список настроек 'Кто может писать на стене группы'. Исправлено.