### PR TITLE
Убираем стену, если отключен компонент

### DIFF
--- a/system/controllers/users/actions/profile.php
+++ b/system/controllers/users/actions/profile.php
@@ -48,7 +48,7 @@ class actionUsersProfile extends cmsAction {
         //
         // Стена
         //
-        if ($this->options['is_wall']){
+        if ($this->options['is_wall'] && $this->isControllerEnabled('wall')){
 
             $wall_controller = cmsCore::getController('wall', $this->request);
 


### PR DESCRIPTION
При отключении компонента стена, в профиле продолжала выводиться стена пользователя.
Хотя ни добавить новую запись, ни отредактировать уже имеющиеся нельзя. При этом соответствующие ссылки выводились.