### PR TITLE
Очистка списка получателей в цикле

### DIFF
--- a/system/controllers/comments/frontend.php
+++ b/system/controllers/comments/frontend.php
@@ -284,6 +284,7 @@ class comments extends cmsFrontend {
 
         foreach ($moderators as $moderator) {
 
+	    $messenger->clearRecipients();
             $messenger->addRecipient($moderator['id']);
 
             $messenger->sendNoticePM(array(


### PR DESCRIPTION
Если у типа контента 2 модератора, то при получении комментарии на модерацию, уведомление дублируется