### PR TITLE
Обрезка изображений строго по заданному размеру

### DIFF
--- a/system/languages/en/controllers/images/images.php
+++ b/system/languages/en/controllers/images/images.php
@@ -8,7 +8,7 @@
     define('LANG_IMAGES_PRESET_SIZE_W_HINT', 'Not set - fit to height');
     define('LANG_IMAGES_PRESET_SIZE_H', 'Height');
     define('LANG_IMAGES_PRESET_SIZE_H_HINT', 'Not set - fit to width');
-    define('LANG_IMAGES_PRESET_SQUARE', 'Square');
+    define('LANG_IMAGES_PRESET_SQUARE', 'Crop');
     define('LANG_IMAGES_PRESET_QUALITY', 'Quality');
     define('LANG_IMAGES_PRESET_WM', 'Watermark');
     define('LANG_IMAGES_PRESET_WM_ON', 'Apply watermark');

--- a/system/languages/ru/controllers/images/images.php
+++ b/system/languages/ru/controllers/images/images.php
@@ -8,7 +8,7 @@
     define('LANG_IMAGES_PRESET_SIZE_W_HINT', 'Не указано - определится пропорционально высоте');
     define('LANG_IMAGES_PRESET_SIZE_H', 'Высота');
     define('LANG_IMAGES_PRESET_SIZE_H_HINT', 'Не указано - определится пропорционально ширине');
-    define('LANG_IMAGES_PRESET_SQUARE', 'Квадратный');
+    define('LANG_IMAGES_PRESET_SQUARE', 'Обрезать');
     define('LANG_IMAGES_PRESET_QUALITY', 'Качество');
     define('LANG_IMAGES_PRESET_WM', 'Водяной знак');
     define('LANG_IMAGES_PRESET_WM_ON', 'Накладывать водяной знак');

--- a/system/libs/files.helper.php
+++ b/system/libs/files.helper.php
@@ -446,7 +446,11 @@ function img_resize($src, $dest, $maxwidth, $maxheight=160, $is_square=false, $q
 
     if ($is_square) {
 
-        $idest = imagecreatetruecolor($maxwidth, $maxwidth);
+        $idest = imagecreatetruecolor($maxwidth, $maxheight);
+		
+		// Определяем пропорции целевого и исходного изображения
+		$proportions_target = $maxwidth / $maxheight;
+		$proportions_source = $new_width / $new_height;
 
         if ($format == 'jpeg') {
 
@@ -461,21 +465,21 @@ function img_resize($src, $dest, $maxwidth, $maxheight=160, $is_square=false, $q
 
         }
 
-        // вырезаем квадратную серединку по x, если фото горизонтальное
-        if ($new_width > $new_height) {
+        // вырезаем серединку по x, если фото горизонтальное
+        if ($proportions_source > $proportions_target) {
 
-            imagecopyresampled($idest, $isrc, 0, 0, round(( max($new_width, $new_height) - min($new_width, $new_height) ) / 2), 0, $maxwidth, $maxwidth, min($new_width, $new_height), min($new_width, $new_height));
+            imagecopyresampled($idest, $isrc, 0, 0, round(( max($new_width, $new_height) - min($new_width, $new_height) ) / 2), 0, $maxwidth, $maxheight, $maxwidth * ($new_height / $maxheight), $new_height);
 
         }
 
-        // вырезаем квадратную верхушку по y,
-        if ($new_width < $new_height) {
-            imagecopyresampled($idest, $isrc, 0, 0, 0, 0, $maxwidth, $maxwidth, min($new_width, $new_height), min($new_width, $new_height));
+        // вырезаем верхушку по y,
+        if ($proportions_source < $proportions_target) {
+            imagecopyresampled($idest, $isrc, 0, 0, 0, 0, $maxwidth, $maxheight, $new_width, $maxheight * ($new_width / $maxwidth));
         }
 
-        // квадратная картинка масштабируется без вырезок
-        if ($new_width == $new_height) {
-            imagecopyresampled($idest, $isrc, 0, 0, 0, 0, $maxwidth, $maxwidth, $new_width, $new_width);
+        // картинка масштабируется без вырезок
+        if ($proportions_source == $proportions_target) {
+            imagecopyresampled($idest, $isrc, 0, 0, 0, 0, $maxwidth, $maxheight, $new_width, $new_height);
         }
 
     } else {


### PR DESCRIPTION
Обрезка изображений не квадратом, а строго по заданному размеру.
При расчете координат для функции imagecopyresampled() были добавлены пропорции (к ширине и высоте), что позволило вычислить горизонтальную или вертикальную обрезку для прямоугольных целевых изображений.
Параметр "Квадратный" переименован в "Обрезать" / "Crop" и говорит о том, что нужно не только масштабировать изображение, но и обрезать до нужных пропорций.