### PR TITLE
Опциональная возможность запускать виджеты только в одной указанной позиции

### DIFF
--- a/system/core/core.php
+++ b/system/core/core.php
@@ -733,8 +733,10 @@ class cmsCore {
 
     /**
      * Запускает все виджеты, привязанные к текущей странице
+     * или виджеты в указанной позиции
+     * @param string $position Имя позиции для обработки
      */
-    public function runWidgets(){
+    public function runWidgets($position = ''){
 
         // в админке нам виджеты не нужны
         if ($this->controller == 'admin') { return; }
@@ -754,7 +756,7 @@ class cmsCore {
                 if(!empty($widget['controller']) && !cmsController::enabled($widget['controller'])){
                     continue;
                 }
-                $this->runWidget($widget);
+                if (!$position || $widget['position'] == $position) { $this->runWidget($widget); }
             }
         }
 


### PR DESCRIPTION
На форуме уже несколько раз спрашивали про возможность вывода виджетов в шаблонах списка и записи контента. Например, нужно что-то выводить после заголовка статей или после фильтров.
Сейчас это стандартными средствами сделать невозможно или можно сделать через бооольшой костыль в виде предварительного (второго на странице) вызова runWidgets() до его вызова в index.php. Сам понимаешь, считать все виджеты по два раза - это вообще не подходящий вариант.

Предлагаю добавить в runWidgets() один опциональный параметр $position и передавать в него имя позиции, если нужно просчитать виджеты только в ней. Тогда можно легко вызывать виджеты в шаблоне:
```
<?php cmsCore::getInstance()->runWidgets('main-body-top'); ?>
<?php $this->widgets('main-body-top'); ?>
```
При этом при вызове runWidgets() в index.php повторно считаться будет только одна эта позиция, а не все. Может решение и не идеальное, но рабочее и даст нужные возможности разработчикам.