### PR TITLE
Описание закрытых групп

### DIFF
--- a/templates/default/controllers/groups/group_closed.tpl.php
+++ b/templates/default/controllers/groups/group_closed.tpl.php
@@ -13,6 +13,12 @@
 
 <div id="group_profile">
 
+	<div class="sess_messages">
+		<div class="message_info">
+			<?php echo LANG_GROUP_IS_CLOSED; ?>
+		</div>
+	</div>
+
     <div id="left_column" class="column">
 
         <div id="logo" class="block">
@@ -23,19 +29,13 @@
 
     <div id="right_column" class="column">
 
-        <div id="information" class="content_item block">
+		<div id="information" class="content_item block">
 
-            <div class="sess_messages">
-                <div class="message_info">
-                    <?php echo LANG_GROUP_IS_CLOSED; ?>
-                </div>
-            </div>
+			<div class="group_description">
+				<?php echo cmsEventsManager::hook('html_filter', $group['description']); ?>
+			</div>
 
-            <div class="group_description">
-                <?php echo cmsEventsManager::hook('html_filter', $group['description']); ?>
-            </div>
-
-        </div>
+		</div>
 
     </div>
 

--- a/templates/default/controllers/groups/group_closed.tpl.php
+++ b/templates/default/controllers/groups/group_closed.tpl.php
@@ -25,8 +25,14 @@
 
         <div id="information" class="content_item block">
 
+            <div class="sess_messages">
+                <div class="message_info">
+                    <?php echo LANG_GROUP_IS_CLOSED; ?>
+                </div>
+            </div>
+
             <div class="group_description">
-                <?php echo LANG_GROUP_IS_CLOSED; ?>
+                <?php echo cmsEventsManager::hook('html_filter', $group['description']); ?>
             </div>
 
         </div>


### PR DESCRIPTION
Предлагается не скрывать описание закрытых групп.
Обычно описание не содержит приватной информации, а пользователи смогут получить представление о группе не только из названия.

Решение подсказано [на форуме](http://www.instantcms.ru/forum/thread26978-1.html#259586) пользователем **Lora**