### PR TITLE
Описание закрытых групп

### DIFF
--- a/templates/default/controllers/groups/group_closed.tpl.php
+++ b/templates/default/controllers/groups/group_closed.tpl.php
@@ -13,6 +13,12 @@
 
 <div id="group_profile">
 
+    <div class="sess_messages">
+		<div class="message_info">
+			<?php echo LANG_GROUP_IS_CLOSED; ?>
+		</div>
+	</div>
+
     <div id="left_column" class="column">
 
         <div id="logo" class="block">
@@ -26,7 +32,7 @@
         <div id="information" class="content_item block">
 
             <div class="group_description">
-                <?php echo LANG_GROUP_IS_CLOSED; ?>
+                <?php echo cmsEventsManager::hook('html_filter', $group['description']); ?>
             </div>
 
         </div>


### PR DESCRIPTION
Предлагается не скрывать описание закрытых групп.
Дать пользователям возможность получить представление о группе не только по названию.