### PR TITLE
Проблемы при Объединении CSS, когда указана версия

### DIFF
--- a/system/core/template.php
+++ b/system/core/template.php
@@ -893,7 +893,7 @@ class cmsTemplate {
 
         foreach($files as $file){
             if (in_array($file, $this->head_css_no_merge)) { continue; }
-            $file_path = $this->site_config->root_path . $file;
+            $file_path = $this->site_config->root_path . strtok($file, '?');
             $contents = file_get_contents($file_path);
             $contents = $this->convertCSSUrlsToAbsolute($contents, $file);
             $contents = string_compress($contents);


### PR DESCRIPTION
Здравствуйте, если включена Объединять CSS, при подключении CSS файла, где указана версия, например:
$this->addCSS('ПУТЬ_К_ФАЙЛУ/style.css?ver=1.0.0');
Получаем ошибку 
Warning: file_get_contents(ПУТЬ_К_ФАЙЛУ/style.css?ver=1.0.0) [function.file-get-contents]: failed to open stream: No such file or directory in \system\core\template.php on line 897