### PR TITLE
Правильный пресет для большой аватарки в ленте активности

### DIFF
--- a/system/controllers/users/actions/profile_edit.php
+++ b/system/controllers/users/actions/profile_edit.php
@@ -111,7 +111,7 @@ class actionUsersProfileEdit extends cmsAction {
                             'images'        => array(
                                 array(
                                     'url' => href_to_rel('users', $profile['id']),
-                                    'src' => html_image_src($new['avatar'], 'normal')
+                                    'src' => html_image_src($new['avatar'], $fields['avatar']['options']['size_full'])
                                 )
                             ),
                             'images_count'  => 1


### PR DESCRIPTION
Исправление мелкого бага в ленте активности. При добавлении аватарки не используются заданный в опциях профиля пресет, а берётся просто "normal".