### PR TITLE
Редиректим на правильный адрес записи

### DIFF
--- a/system/controllers/content/actions/item_view.php
+++ b/system/controllers/content/actions/item_view.php
@@ -44,6 +44,10 @@ class actionContentItemView extends cmsAction {
         // Получаем запись
         $item = $this->model->getContentItemBySLUG($ctype['name'], $slug);
         if (!$item) { return cmsCore::error404(); }
+	    
+	if (strcmp($slug, $item['slug']) != false){ 
+	    $this->redirect(href_to($ctype['name'], $item['slug'] . '.html'), 301);
+	}
 
         // Проверяем прохождение модерации
         $is_moderator = $this->cms_user->is_admin;

--- a/system/controllers/photos/actions/upload.php
+++ b/system/controllers/photos/actions/upload.php
@@ -131,8 +131,9 @@ class actionPhotosUpload extends cmsAction{
                     $small_preset = end($_presets);
 
                     $activity_thumb_images[] = array(
-                        'url' => href_to_rel('photos', $photo['slug'].'.html'),
-                        'src' => html_image_src($photo['image'], $small_preset)
+                        'url'   => href_to_rel('photos', $photo['slug'].'.html'),
+                        'src'   => html_image_src($photo['image'], $small_preset),
+			'title' => $photo['title']
                     );
                 }
             }

--- a/system/controllers/rss/actions/feed.php
+++ b/system/controllers/rss/actions/feed.php
@@ -12,6 +12,8 @@ class actionRssFeed extends cmsAction {
         if (!$feed || !$feed['is_enabled']) {
             cmsCore::error404();
         }
+        
+        $template = $this->request->get('template', '');
 
         if ($feed['is_cache']) {
 
@@ -44,6 +46,24 @@ class actionRssFeed extends cmsAction {
         }
 
         list($feed, $category, $author) = $data;
+        
+        if (!empty($template)){	
+		
+			$tpls = cmsCore::getFilesList('templates/'.cmsConfig::get('template').'/controllers/rss/', '*.tpl.php');
+			$default_tpls = cmsCore::getFilesList('templates/default/controllers/rss/', '*.tpl.php');
+			$tpls = array_unique(array_merge($tpls, $default_tpls));
+			
+			$templates = array();
+			
+			foreach ($tpls as $tpl) {
+				$templates[str_replace('.tpl.php', '', $tpl)] = $tpl;
+			}
+			
+			if(array_key_exists($template, $templates)){				
+				$feed['template'] = $template;
+			}
+			
+        }
 
 		header('Content-type: application/rss+xml; charset=utf-8');
 

--- a/templates/default/controllers/activity/list.tpl.php
+++ b/templates/default/controllers/activity/list.tpl.php
@@ -58,8 +58,8 @@
                         <div class="images">
                             <?php foreach($item['images'] as $image){ ?>
                                 <div class="image">
-                                    <a href="<?php echo $image['url']; ?>">
-										<img src="<?php echo $image['src']; ?>">
+                                    <a href="<?php echo $image['url']; ?>"<?php echo !empty($image['alt']) ? " title='{$image['alt']}'" : ""; ?>>
+					<img src="<?php echo $image['src']; ?>"<?php echo !empty($image['alt']) ? " alt='{$image['alt']}'" : ""; ?>>
                                     </a>
                                 </div>
                             <?php } ?>

--- a/templates/default/controllers/activity/list.tpl.php
+++ b/templates/default/controllers/activity/list.tpl.php
@@ -58,8 +58,8 @@
                         <div class="images">
                             <?php foreach($item['images'] as $image){ ?>
                                 <div class="image">
-                                    <a href="<?php echo $image['url']; ?>"<?php echo !empty($image['alt']) ? " title='{$image['alt']}'" : ""; ?>>
-					<img src="<?php echo $image['src']; ?>"<?php echo !empty($image['alt']) ? " alt='{$image['alt']}'" : ""; ?>>
+                                    <a href="<?php echo $image['url']; ?>"<?php echo !empty($image['title']) ? " title='{$image['title']}'" : ""; ?>>
+					<img src="<?php echo $image['src']; ?>"<?php echo !empty($image['title']) ? " alt='{$image['title']}'" : ""; ?>>
                                     </a>
                                 </div>
                             <?php } ?>


### PR DESCRIPTION
В текущем состоянии, в Яндекс панеле вебмастера появляются дубли страниц записей из-за того, что если указывать slug записи в разном регистре (так и не понятно откуда они появились ), то отображается одна и та же запись.
Данная корректировка редиректит на правильный адрес записи в нужном регистре, тем самым исключает появление дублей страниц.