### PR TITLE
Не правильно отображает вкладки в select

### DIFF
--- a/templates/default/js/core.js
+++ b/templates/default/js/core.js
@@ -55,7 +55,7 @@ $(document).ready(function(){
             var tabs = $(this);
 
             var dropdown = $("<select>").prependTo(tabs);
-            $("ul > li > a", tabs).each(function() {
+            $("> ul > li > a", tabs).each(function() {
                 var el = $(this);
                 var attr = {
                     value   : el.attr('href'),


### PR DESCRIPTION
Когда система создает select версию вкладок, в качестве опции берет все "ul > li > a" которые есть в блоке .tabs-menu, а надо что бы брал только первый ul, иначе в мобильных версиях в select отображается ссылки, которые есть внутри вкладок, где родитель ul > li