### PR TITLE
Warning: str_repeat()

### DIFF
--- a/system/core/config.php
+++ b/system/core/config.php
@@ -183,7 +183,7 @@ class cmsConfig {
             $tabs = 10 - ceil((mb_strlen($key)+3)/4);
 
             $dump .= "\t'{$key}'";
-            $dump .= str_repeat("\t", $tabs);
+            $dump .= str_repeat("\t", $tabs > 0 ? $tabs : 0);
             $dump .= "=> $value,\n";
 
         }


### PR DESCRIPTION
Если ключь будет более 40 символов то вылетел предупреждение 
`Warning: str_repeat(): Second argument has to be greater than or equal to 0`
т.к в функции **str_repeat()**  второй параметр должен быть **`>=0`**