### PR TITLE
cmsController: Проверка на кол-во параметров при запуске action'а вынесена в метод validateParamsCount

### DIFF
--- a/system/controllers/admin/frontend.php
+++ b/system/controllers/admin/frontend.php
@@ -43,6 +43,10 @@ class admin extends cmsFrontend {
 
 	}
 
+    protected function validateParamsCount($class, $method_name, &$params) {
+        // проверка на кол-во параметров в контроллере admin отключена
+    }
+
     public function before($action_name) {
 
         parent::before($action_name);

--- a/system/controllers/admin/frontend.php
+++ b/system/controllers/admin/frontend.php
@@ -43,8 +43,9 @@ class admin extends cmsFrontend {
 
 	}
 
-    protected function validateParamsCount($class, $method_name, &$params) {
+    protected function validateParamsCount($class, $method_name, $params) {
         // проверка на кол-во параметров в контроллере admin отключена
+        return true;
     }
 
     public function before($action_name) {

--- a/system/core/controller.php
+++ b/system/core/controller.php
@@ -457,16 +457,7 @@ class cmsController {
             // Если файла нет, ищем метод класса
             if (method_exists($this, $method_name)){
 
-                // проверяем максимальное число аргументов экшена
-                if ($this->name != 'admin'){
-                    $rf = new ReflectionMethod($this, $method_name);
-                    // кол-во переданных параметров
-                    $current_params = count($params);
-                    // передано больше чем нужно параметров
-                    if ($rf->getNumberOfParameters() < $current_params) { cmsCore::error404(); }
-                    // передано меньше чем нужно параметров
-                    if ($rf->getNumberOfRequiredParameters() > $current_params) { cmsCore::error404(); }
-                }
+                $this->validateParamsCount($this, $method_name, $params);
 
                 // сохраняем название текущего экшена
                 $this->current_action = $action_name;
@@ -501,6 +492,25 @@ class cmsController {
     }
 
     /**
+     * Проверяем максимальное число аргументов экшена
+     * Выбрасываем ошибку, если количество параметров не соответствует кол-ву аргументов
+     * Для отключения проверки, можно переопределить этот метод с пустой реализацией
+     * (например см. в контроллере admin)
+     * @param string|object $class Имя класса или текущий объект контроллера $this
+     * @param string $method_name Имя метода
+     * @param array $params Массив параметров
+     */
+    protected function validateParamsCount($class, $method_name, &$params) {
+        $rf = new ReflectionMethod($class, $method_name);
+        // кол-во переданных параметров
+        $current_params = count($params);
+        // передано больше чем нужно параметров
+        if ($rf->getNumberOfParameters() < $current_params) { cmsCore::error404(); }
+        // передано меньше чем нужно параметров
+        if ($rf->getNumberOfRequiredParameters() > $current_params) { cmsCore::error404(); }
+    }
+
+    /**
      * Возвращает путь к файлу экшена (./actions/$action_name.php по умолчанию)
      * @param string $action_name
      * @return string
@@ -529,16 +539,7 @@ class cmsController {
             cmsCore::error(sprintf(ERR_CLASS_NOT_DEFINED, str_replace(PATH, '', $action_file), $class_name));
         }
 
-        // проверяем максимальное число аргументов экшена
-        if ($this->name != 'admin'){
-            $rf = new ReflectionMethod($class_name, 'run');
-            // кол-во переданных параметров
-            $current_params = count($params);
-            // передано больше чем нужно параметров
-            if ($rf->getNumberOfParameters() < $current_params) { cmsCore::error404(); }
-            // передано меньше чем нужно параметров
-            if ($rf->getNumberOfRequiredParameters() > $current_params) { cmsCore::error404(); }
-        }
+        $this->validateParamsCount($class_name, 'run', $params);
 
         // сохраняем название текущего экшена
         $this->current_action = $action_name;

--- a/system/core/controller.php
+++ b/system/core/controller.php
@@ -457,7 +457,7 @@ class cmsController {
             // Если файла нет, ищем метод класса
             if (method_exists($this, $method_name)){
 
-                $this->validateParamsCount($this, $method_name, $params);
+                if (!$this->validateParamsCount($this, $method_name, $params)) { cmsCore::error404(); }
 
                 // сохраняем название текущего экшена
                 $this->current_action = $action_name;
@@ -493,21 +493,22 @@ class cmsController {
 
     /**
      * Проверяем максимальное число аргументов экшена
-     * Выбрасываем ошибку, если количество параметров не соответствует кол-ву аргументов
-     * Для отключения проверки, можно переопределить этот метод с пустой реализацией
-     * (например см. в контроллере admin)
+     * Возвращает false если переданных количество параметров не соответствует кол-ву аргументов экшена
+     * Для отключения проверки, можно переопределить этот метод (например см. в контроллере admin)
      * @param string|object $class Имя класса или текущий объект контроллера $this
      * @param string $method_name Имя метода
      * @param array $params Массив параметров
+     * @return bool Результат проверки
      */
-    protected function validateParamsCount($class, $method_name, &$params) {
+    protected function validateParamsCount($class, $method_name, $params) {
         $rf = new ReflectionMethod($class, $method_name);
         // кол-во переданных параметров
         $current_params = count($params);
         // передано больше чем нужно параметров
-        if ($rf->getNumberOfParameters() < $current_params) { cmsCore::error404(); }
+        if ($rf->getNumberOfParameters() < $current_params) return false;
         // передано меньше чем нужно параметров
-        if ($rf->getNumberOfRequiredParameters() > $current_params) { cmsCore::error404(); }
+        if ($rf->getNumberOfRequiredParameters() > $current_params) return false;
+        return true;
     }
 
     /**
@@ -539,7 +540,7 @@ class cmsController {
             cmsCore::error(sprintf(ERR_CLASS_NOT_DEFINED, str_replace(PATH, '', $action_file), $class_name));
         }
 
-        $this->validateParamsCount($class_name, 'run', $params);
+        if (!$this->validateParamsCount($class_name, 'run', $params)) { cmsCore::error404(); }
 
         // сохраняем название текущего экшена
         $this->current_action = $action_name;


### PR DESCRIPTION
чтобы убрать дублирование кода и иметь возможность отключать или переопределять эту проверку в собственных модулях. Проверка была отключена для модуля admin, так что там этот метод переопределен.