### PR TITLE
cmsUser: добавлен статический метод getId 

### DIFF
--- a/system/core/user.php
+++ b/system/core/user.php
@@ -34,6 +34,10 @@ class cmsUser {
         return self::getInstance()->$key;
     }
 
+    public static function getId() {
+        return self::getInstance()->id;
+    }
+
     public static function getIp(){
 
         if(self::$_ip === null){


### PR DESCRIPTION
для более удобного получения id текущего пользователя cmsUser::getId() вместо cmsUser::get('id') и cmsUser::getInstance()->id