### PR TITLE
Исправлено: установка активного элемента select'a списка табов

### DIFF
--- a/templates/default/js/core.js
+++ b/templates/default/js/core.js
@@ -79,7 +79,7 @@ icms.menu = (function ($) {
                         value   : el.attr('href'),
                         text    : el.text()
                     };
-                    if(window.location.pathname.indexOf(el.attr('href')) === 0){
+                    if(el.parent('li').hasClass('active')){
                         attr.selected = true;
                     }
                     $("<option>", attr).appendTo(dropdown);


### PR DESCRIPTION
(select отображается в мобильном виде вместо табов)
сравнивалось по ссылке (видимо код был скопирован с аналогичной функции для меню на 59 строке того же файла)
исправлено на проверку наличия класса active у род.тега li