### PR TITLE
Добавляем проверку в массив

### DIFF
--- a/templates/default/js/core.js
+++ b/templates/default/js/core.js
@@ -51,7 +51,7 @@ icms.menu = (function ($) {
             var el = $(this);
             var nav_level = $("nav .menu").parents().length;
             var el_level = $(this).parents().length - nav_level;
-            var pad = new Array(el_level-2 + 1).join('-') + ' ';
+            var pad = ((el_level-2 + 1) >= 1) ? new Array(el_level-2 + 1).join('-') + ' ' : '';
             var attr = {
                 value   : el.attr('href'),
                 text    : pad + el.text()


### PR DESCRIPTION
В некоторых шаблона, где структура меню не такой как в default, это строка вырубает всю работу других стриптов.
Покопавшись выяснил что el_level-2 + 1 возвращает отрицательное число в некоторых пунктах меню, поэтому добавил проверку.

Вообще хотелось бы опцию, где можно вообще не выводить этот мобильное меню select, где разработчик в своем шаблоне пишет типа icms.core.disable_select_menu = true; и данный код не выполниться.