### PR TITLE
Недоступны языковые константы при загрузке виджетов

### DIFF
--- a/system/controllers/admin/actions/widgets_load.php
+++ b/system/controllers/admin/actions/widgets_load.php
@@ -8,6 +8,8 @@ class actionAdminWidgetsLoad extends cmsAction {
             cmsCore::error404();
         }
 
+        cmsCore::loadAllControllersLanguages();
+
         $page_id  = $this->request->get('page_id', 0);
         $template = $this->request->get('template', '');
 


### PR DESCRIPTION
На странице site.ru/admin/widgets при выборе страниц сторонних компонентов (например форум) появляется предупреждение, которое блокирует работу яваскрипта по загрузке виджетов этой страницы.

PHP Warning:  constant() [<a href='0function.constant0'>function.constant0</a>]: Couldn't find constant LANG_WP_FORUM_MAIN_PAGE in system\controllers\widgets\model.php on line 275