### PR TITLE
Добавил возможность выбора обрезки текста в списке по словам и по символам. 

### DIFF
--- a/system/fields/text.php
+++ b/system/fields/text.php
@@ -37,15 +37,29 @@ class fieldText extends cmsFormField {
                 'title' => LANG_PARSER_BUILD_REDIRECT_LINK,
                 'is_visible' => cmsController::enabled('redirect')
             )),
-            new fieldNumber('teaser_len', array(
+            new fieldList('teaser_len_choice', array(
                 'title' => LANG_PARSER_HTML_TEASER_LEN,
-                'hint' => LANG_PARSER_HTML_TEASER_LEN_HINT,
-				'extended_option' => true
+                'items'     => [
+                    'none'  => LANG_PARSER_HTML_TEASER_NONE,
+                    'symbols' => LANG_PARSER_HTML_TEASER_SYMBOLS,
+                    'words'  => LANG_PARSER_HTML_TEASER_WORDS
+                ],
+                'hint' => LANG_PARSER_HTML_TEASER_CHOICE
+            )),
+            new fieldNumber('teaser_len_words', array(
+                'title' => LANG_PARSER_HTML_TEASER_QUANTITY_WORDS,
+                'default' => 50,
+                'visible_depend' => ['options:teaser_len_choice' => ['show' => ['words']]]
+            )),
+            new fieldNumber('teaser_len_symbols', array(
+                'title' => LANG_PARSER_HTML_TEASER_QUANTITY_SYMBOLS,
+                'default' => 100,
+                'hint'  => LANG_PARSER_HTML_TEASER_SYMBOLS_HINT,
+                'visible_depend' => ['options:teaser_len_choice' => ['show' => ['symbols']]]
             )),
             new fieldCheckbox('show_show_more', array(
                 'title' => LANG_PARSER_SHOW_SHOW_MORE,
                 'default' => false,
-                'visible_depend' => array('options:teaser_len' => array('hide' => array(''))),
 				'extended_option' => true
             )),
             new fieldCheckbox('in_fulltext_search', array(
@@ -83,17 +97,22 @@ class fieldText extends cmsFormField {
             return '<p class="private_field_hint text-muted">'.$this->item['private_item_hint'].'</p>';
         }
 
-        $max_len = $this->getOption('teaser_len', 0);
-
-        if ($max_len){
-
-            $value = string_short($value, $max_len);
-
-            if($this->getOption('show_show_more') && !empty($this->item['ctype']['name']) && !empty($this->item['slug'])){
-                $value .= '<span class="d-block mt-2"><a class="read-more btn btn-outline-info btn-sm" href="'.href_to($this->item['ctype']['name'], $this->item['slug'].'.html').'">'.LANG_MORE.'</a></span>';
-            }
-
-            return $value;
+        switch($choice) {
+            case 'symbols':
+                $max_len = $this->getOption('teaser_len_symbols');
+                $value = string_short($value, $max_len);
+                return $value."...";
+                break;
+           case 'words':
+                $max_len = $this->getOption('teaser_len_words');
+                //string_short() работает некорректно, либо я не разобрался как он работает ¯\_(ツ)_/¯. Метод лежит в string.helper.php
+                //$value = string_short($value, $max_len, '...', 'w'); 
+                $slice_string = explode(" ", $value);
+                $slice_string = array_slice($slice_string, 0, $max_len);
+                $value = implode(" ", $slice_string);
+                $value .= '...';
+                return $value;
+                break;          
         }
 
         return parent::parseTeaser($value);

--- a/system/languages/en/language.php
+++ b/system/languages/en/language.php
@@ -149,6 +149,13 @@
     define('LANG_PARSER_HTML_TEASER_LEN',    'Truncate text length in list view');
     define('LANG_PARSER_HTML_TEASER_LEN_HINT','The text will be truncated to a specified length, the formatting will be removed');
     define('LANG_PARSER_HTML_TEASER_POSTFIX', 'Add text to the received line');
+    define('LANG_PARSER_HTML_TEASER_CHOICE', 'How do you want to crop the text: by words or by characters?');
+    define('LANG_PARSER_HTML_TEASER_NONE', 'Do not crop');
+    define('LANG_PARSER_HTML_TEASER_SYMBOLS', 'Cropping by characters');
+    define('LANG_PARSER_HTML_TEASER_WORDS', 'Pruning by words');
+    define('LANG_PARSER_HTML_TEASER_QUANTITY_WORDS', 'Number of words displayed');
+    define('LANG_PARSER_HTML_TEASER_QUANTITY_SYMBOLS', 'Number of characters displayed');
+    define('LANG_PARSER_HTML_TEASER_SYMBOLS_HINT', 'Spaces are also counted as characters');
     define('LANG_PARSER_HTML_TEASER_TYPE',    'Trim type');
     define('LANG_PARSER_HTML_TEASER_TYPE_NULL','Cut anywhere');
     define('LANG_PARSER_HTML_TEASER_TYPE_S', 'The last sentence');

--- a/system/languages/ru/language.php
+++ b/system/languages/ru/language.php
@@ -150,6 +150,13 @@
     define('LANG_PARSER_HTML_TEASER_LEN_HINT','Текст будет обрезан до указанной длины, форматирование будет удалено');
     define('LANG_PARSER_HTML_TEASER_POSTFIX', 'Добавлять текст к полученной строке');
     define('LANG_PARSER_HTML_TEASER_TYPE',    'Тип обрезки');
+    define('LANG_PARSER_HTML_TEASER_CHOICE', 'Как Вы хотите обрезать текст: по словам или по символам?');
+    define('LANG_PARSER_HTML_TEASER_NONE', 'Не обрезать');
+    define('LANG_PARSER_HTML_TEASER_SYMBOLS', 'Обрезка по символам');
+    define('LANG_PARSER_HTML_TEASER_WORDS', 'Обрезка по словам');
+    define('LANG_PARSER_HTML_TEASER_QUANTITY_WORDS', 'Количество отображаемых слов');
+    define('LANG_PARSER_HTML_TEASER_QUANTITY_SYMBOLS', 'Количество отображаемых символов');
+    define('LANG_PARSER_HTML_TEASER_SYMBOLS_HINT', 'Пробелы так же учитываются как символы');
     define('LANG_PARSER_HTML_TEASER_TYPE_NULL','Обрезать в любом месте');
     define('LANG_PARSER_HTML_TEASER_TYPE_S', 'По последнему предложению');
     define('LANG_PARSER_HTML_TEASER_TYPE_W', 'По последнему слову');


### PR DESCRIPTION
Добавил возможность выбора обрезки текста в списке по словам и по символам. Так же включить кнопку 'подробнее' можно без обрезки текста. 
![image](https://user-images.githubusercontent.com/71038326/147566424-e7cc517f-c332-4934-b792-7b1c2ba3fe80.png)
![image](https://user-images.githubusercontent.com/71038326/147566226-b4a4a15c-fea9-49dd-bd65-975c32493b01.png)

Обрезка символов делается через метод `string_short()` из хелпера, а обрезку по словам настроить не смог - слова вообще не отображаются, поэтому делал через разбивку строки на массив. Так хоть работает.

На текущем билде системы не тестировал, писал под `2.14.3`, хз будет ли работать на новой сборке. 