### PR TITLE
Добавил опции приватности пользователя

### DIFF
--- a/system/controllers/users/actions/profile.php
+++ b/system/controllers/users/actions/profile.php
@@ -117,41 +117,49 @@ class actionUsersProfile extends cmsAction {
 
         // Если включена опция "просмотр даты регистрации"
         if (!empty($this->options['show_reg_data'])) {
-
-            $fields['date_reg'] = [
-                'title' => LANG_USERS_PROFILE_REGDATE,
-                'text'  => string_date_age_max($profile['date_reg'], true)
-            ];
+            // Проверяем настройки приватности (последний визит)
+            if(cmsUser::getInstance()->isPrivacyAllowed($profile, 'users_show_reg_data')) {
+                $fields['date_reg'] = [
+                    'title' => LANG_USERS_PROFILE_REGDATE,
+                    'text'  => string_date_age_max($profile['date_reg'], true)
+                ];
+            }
         }
 
         // Если включена опция "показать последний визит пользователя"
         if (!empty($this->options['show_last_visit'])) {
             // Если пользователь не в сети
             if (!$profile['is_online']) {
-                $fields['date_log'] = [
-                    'title' => LANG_USERS_PROFILE_LOGDATE,
-                    'text'  => string_date_age_max($profile['date_log'], true)
-                ];
+                // Проверяем настройки приватности (последний визит)
+                if(cmsUser::getInstance()->isPrivacyAllowed($profile, 'users_show_last_visit')) {
+                    $fields['date_log'] = [
+                        'title' => LANG_USERS_PROFILE_LOGDATE,
+                        'text'  => string_date_age_max($profile['date_log'], true)
+                    ];
+                }
             }
         }
 
         // Если включена опция "показывать группы пользователя"
         if (!empty($this->options['show_user_groups'])) {
 
-            // Получаем группы пользователя
-            $groups = $this->model->getGroups();
+            // Проверяем настройки приватности (группы пользователя)
+            if(cmsUser::getInstance()->isPrivacyAllowed($profile, 'users_show_user_groups')) {
+                // Получаем группы пользователя
+                $groups = $this->model->getGroups();
 
-            $groups_title = [];
+                $groups_title = [];
 
-            // Заполняем массив именами групп
-            foreach ($profile['groups'] as $group_id) {
-                $groups_title[] = $groups[$group_id]['title'];
+                // Заполняем массив именами групп
+                foreach ($profile['groups'] as $group_id) {
+                    $groups_title[] = $groups[$group_id]['title'];
+                }
+
+                $fields['groups'] = [
+                    'title' => LANG_GROUPS,
+                    'text'  => implode(', ', $groups_title)
+                ];
             }
-
-            $fields['groups'] = [
-                'title' => LANG_GROUPS,
-                'text'  => implode(', ', $groups_title)
-            ];
         }
 
         if ($profile['inviter_id'] && !empty($profile['inviter_nickname'])) {

--- a/system/controllers/users/hooks/user_privacy_types.php
+++ b/system/controllers/users/hooks/user_privacy_types.php
@@ -2,20 +2,44 @@
 
 class onUsersUserPrivacyTypes extends cmsAction {
 
-    public function run(){
+    public function run() {
 
-        $types = array();
+        $types = [];
 
-        $types['users_profile_view'] = array(
+        $types['users_profile_view'] = [
             'title'   => LANG_USERS_PRIVACY_PROFILE_VIEW,
-            'options' => array('', 'anyone', 'friends')
-        );
+            'options' => ['', 'anyone', 'friends']
+        ];
 
-        if(!empty($this->options['is_friends_on'])){
-            $types['users_friendship'] = array(
+        if(!empty($this->options['is_friends_on'])) {
+            $types['users_friendship'] = [ 
                 'title'   => LANG_USERS_PRIVACY_FRIENDSHIP,
-                'options' => array('', 'anyone')
-            );
+                'options' => ['', 'anyone']
+            ];
+        }
+
+        //Если в админке включена опция "Показывать дату регистрации пользователя"
+        if(!empty($this->options['show_reg_data'])) {
+            $types['users_show_reg_data'] = [
+                'title'   => LANG_USERS_PRIVACY_SHOW_REG_DATA,
+                'options' => ['', 'anyone', 'friends']
+            ];
+        }
+
+        //Если в админке включена опция "Показывать последний визит пользователя"
+        if(!empty($this->options['show_last_visit'])) {
+            $types['users_show_last_visit'] = [
+                'title'   => LANG_USERS_PRIVACY_SHOW_LAST_VISIT,
+                'options' => ['', 'anyone', 'friends']
+            ];
+        }
+
+        //Если в админке включена опция "Показывать группы пользователя"
+        if(!empty($this->options['show_user_groups'])) {
+            $types['users_show_user_groups'] = [
+                'title'   => LANG_USERS_PRIVACY_SHOW_USER_GROUPS,
+                'options' => ['', 'anyone', 'friends']
+            ];
         }
 
         return $types;

--- a/system/languages/ru/controllers/users/users.php
+++ b/system/languages/ru/controllers/users/users.php
@@ -142,8 +142,11 @@
     define('LANG_USERS_NOTIFY_FRIEND_ACCEPT',  'Уведомлять об одобренных запросах дружбы');
     define('LANG_USERS_NOTIFY_FRIEND_DELETE',  'Уведомлять о прекращении дружбы');
 
-    define('LANG_USERS_PRIVACY_FRIENDSHIP',    'Кто может отправлять мне запросы дружбы?');
+    define('LANG_USERS_PRIVACY_FRIENDSHIP',    'Кто может отправлять вам запросы дружбы?');
     define('LANG_USERS_PRIVACY_PROFILE_VIEW',  'Кто может просматривать ваш профиль?');
+    define('LANG_USERS_PRIVACY_SHOW_REG_DATA', 'Кто может видеть вашу дату регистрации?');
+    define('LANG_USERS_PRIVACY_SHOW_LAST_VISIT',    'Кто может видеть ваш последний визит?');
+    define('LANG_USERS_PRIVACY_SHOW_USER_GROUPS',   'Кто может видеть ваши группы?');
     define('LANG_USERS_PRIVACY_PROFILE_WALL',  'Кто может писать на вашей стене?');
     define('LANG_USERS_PRIVACY_PROFILE_WALL_REPLY', 'Кто может комментировать записи на стене?');
     define('LANG_USERS_PRIVACY_PROFILE_CTYPE',  'Кто может просматривать список ваших %s?');


### PR DESCRIPTION
Продолжение [этой темы](https://instantcms.ru/forum/kak-otklyuchit-otobrazhenie-daty-registracii-i-poslednego-vizita-v-profiljah-polzovatelei.html?page=3) на форуме.
В настройках `приватности пользователя`, добавил 3 опции:

- [ ] -  "Кто может видеть ваш **последний визит**?"
- [ ] - "Кто может видеть вашу **дату регистрации**?"
- [x] -  "Кто может видеть ваши **группы**?"

Опции появляются в зависимости от настроек в админке.