### PR TITLE
Очистка пустых значений полей типа Список: мультивыбор

### DIFF
--- a/system/fields/listbitmask.php
+++ b/system/fields/listbitmask.php
@@ -251,6 +251,10 @@ class fieldListBitmask extends cmsFormField {
             foreach ($new_rows as $nkey => $title) {
                 $new_item_value .= in_array($nkey, $old_item_values) ? '1' : '0';
             }
+            
+            if(strpos($new_item_value, '1') === false){
+                $new_item_value = NULL;
+            }
 
             // записываем обратно в базу
             $model->update($content_table_name, $id, [


### PR DESCRIPTION
При удалении предустановленных значений может так случиться, что из выбранных пользователем вариантов в записи не останется ни одного. В базе останется набор нулей 0000, на сайте будет выведено пустое поле.