### PR TITLE
{file_name%icon_name} в поле htmlcross

### DIFF
--- a/system/fields/htmlcross.php
+++ b/system/fields/htmlcross.php
@@ -66,7 +66,7 @@ class fieldHtmlcross extends cmsFormField {
     }
 
     public function afterParse($value, $item){
-        return string_replace_keys_values_extended($this->getOption('item_html'), $item);
+        return string_replace_keys_values_extended($value, $item);
     }
 
 }


### PR DESCRIPTION
Иначе не срабатывает вывод иконки по выражению {file_name%icon_name} в тексте