### PR TITLE
Update spyc.class.php

### DIFF
--- a/system/libs/spyc.class.php
+++ b/system/libs/spyc.class.php
@@ -343,18 +343,31 @@ class Spyc {
         if ($value === "\n") {
             return '\n';
         }
-        if (strpos($value, "\n") === false && strpos($value, "'") === false) {
-            return sprintf("'%s'", $value);
+    
+        if (strlen($value) < 3 && strpos($value, "\n") === false) {
+            if (strpos($value, "'") === false) {
+                return sprintf("'%s'", $value);
+            }
+            if (strpos($value, '"') === false) {
+                return sprintf('"%s"', $value);
+            }
         }
-        if (strpos($value, "\n") === false && strpos($value, '"') === false) {
-            return sprintf('"%s"', $value);
-        }
+    
         $exploded = explode("\n", $value);
+        while (isset($exploded[0]) && $exploded[0] === '') {
+            array_shift($exploded);
+        }
+        while (isset($exploded[count($exploded)-1]) && $exploded[count($exploded)-1] === '') {
+            array_pop($exploded);
+        }
+        if (count($exploded) === 1) {
+            return sprintf('"%s"', addslashes($exploded[0]));
+        }
         $newValue = '|';
         $indent += $this->_dumpIndent;
         $spaces = str_repeat(' ', $indent);
         foreach ($exploded as $line) {
-            $newValue .= "\n" . $spaces . ($line);
+            $newValue .= "\n" . $spaces . rtrim($line);
         }
         return $newValue;
     }


### PR DESCRIPTION
При сохранении данных через Spyc::YAMLDump() для многострочных строк (например, HTML-код в виджетах, текстовые поля с переносами) в результирующий YAML добавляется лишний символ | перед содержимым.
Метод _doLiteralBlock() некорректно обрабатывал многострочные строки:

- Не проверял, действительно ли строка требует блочного представления
- Добавлял пустые строки в начало и конец блока
- Для коротких многострочных строк использовал неверный формат

**Что исправлено**

1. Добавлена проверка длины строки — строки короче 3 символов с одним переносом теперь корректно обрамляются в кавычки вместо создания блока |
2. Удаление пустых строк — пустые строки в начале и конце блока теперь отбрасываются
3. Одиночные строки с переносом — если после очистки осталась одна строка, она оборачивается в кавычки с экранированием спецсимволов
4. Корректное формирование блока — строки не содержат лишних пробелов в конце (использован rtrim)